### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flowbuild/diagrams-core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flowbuild/diagrams-core",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowbuild/diagrams-core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "BPMN diagrams manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.2.0](https://github.com/flow-build/diagrams-core/releases/tag/v1.2.0)