### PR TITLE
Workflow Integration, Public Diagrams

### DIFF
--- a/db/migrations/20230125173000_make_user_id_nullable.js
+++ b/db/migrations/20230125173000_make_user_id_nullable.js
@@ -1,0 +1,16 @@
+const { v4: uuid } = require('uuid'); 
+    
+exports.up = function (knex) {
+  return knex.schema.alterTable("diagrams", function (table) {
+    table.setNullable("user_id");
+  });
+};
+
+exports.down = function (knex) {
+  knex("diagrams")
+    .whereNull("user_id")
+    .update("user_id", uuid())
+  return knex.schema.alterTable("diagrams", function (table) {
+    table.dropNullable("user_id");
+  });
+};

--- a/src/diagramCore.js
+++ b/src/diagramCore.js
@@ -44,6 +44,7 @@ class DiagramCore {
     let blueprint;
     if(workflow_data) {
       if(workflow_data.blueprint_spec) {
+        //TODO: verify whether the blueprint_spec already exists in the database
         blueprint = await new BlueprintCore(this._db).saveBlueprint(workflow_data.blueprint_spec)        
         await Diagram.update(diagram.id, { blueprint_id: blueprint.id })
       }

--- a/src/diagramCore.js
+++ b/src/diagramCore.js
@@ -1,6 +1,9 @@
 const { logger } = require('./utils/logger');
 const { PersistorProvider } = require('./persist/provider');
 const { Diagram } = require('./entities/diagram');
+const { BlueprintCore } = require('./blueprintCore');
+const { DiagramToWorkflowCore } = require('./diagramToWorkflowCore');
+const { WorkflowCore } = require('./workflowCore');
 
 class DiagramCore {
 
@@ -31,9 +34,30 @@ class DiagramCore {
 
   async saveDiagram(diagram_obj) {
     logger.debug('saveDiagram service called');
-    const { name, user_id, diagram_xml } = diagram_obj;
+    const { name, user_id, diagram_xml, workflow_data, isPublic } = diagram_obj;
+    let userId;
+    if(!isPublic) {
+      userId = user_id
+    }
+    const diagram = await new Diagram(name, userId, diagram_xml).save();
 
-    return await new Diagram(name, user_id, diagram_xml).save();
+    let blueprint;
+    if(workflow_data) {
+      if(workflow_data.blueprint_spec) {
+        blueprint = await new BlueprintCore(this._db).saveBlueprint(workflow_data.blueprint_spec)        
+        await Diagram.update(diagram.id, { blueprint_id: blueprint.id })
+      }
+      if(workflow_data.id) {
+        const workflow = await new WorkflowCore(this._db).saveWorkflow({ id: workflow_data.id, server: workflow_data.server, blueprint_id: blueprint.id })
+        await new DiagramToWorkflowCore(this._db).saveDiagramToWorkflow({ diagram_id: diagram.id, workflow_id: workflow_data.id })
+        const response = await Diagram.fetch(diagram.id);
+        delete response.diagram_xml;
+        return { ...response, ...{ workflow_id: workflow.id, server: workflow.server } }
+      }      
+    } 
+    
+    return diagram;
+    
   }
 
   async getAllDiagrams() {
@@ -54,16 +78,17 @@ class DiagramCore {
     return await Diagram.fetch(id);
   }
 
-  async getDiagramsByWorkflowId(workflow_id) {
+  async getDiagramsByWorkflowId(workflow_id, user_id = null) {
     logger.debug('getDiagramsByWorkflowId service called');
 
-    return await Diagram.fetchByWorkflowId(workflow_id);
+    return await Diagram.fetchByWorkflowId(workflow_id, user_id);
   }
 
-  async getLatestDiagramByWorkflowId(workflow_id) {
+
+  async getLatestDiagramByWorkflowId(workflow_id, user_id = null) {
     logger.debug('getLatestDiagramByWorkflowId service called');
   
-    return await Diagram.fetchLatestByWorkflowId(workflow_id);
+    return await Diagram.fetchLatestByWorkflowId(workflow_id, user_id);
   }
 
   async getDiagramsByUserAndWF(user_id, workflow_id) {

--- a/src/entities/diagram.js
+++ b/src/entities/diagram.js
@@ -44,13 +44,14 @@ class Diagram extends PersistedEntity {
     }
   }
 
-  constructor(name, user_id, diagram_xml) {
+  constructor(name, user_id, diagram_xml, blueprint_id = null) {
     super();
 
     this.id = uuid();
     this.name = name;
     this.user_id = user_id;
     this.diagram_xml = diagram_xml;
+    this.blueprint_id = blueprint_id
   }
 
 }

--- a/src/persist/knex.js
+++ b/src/persist/knex.js
@@ -1,7 +1,7 @@
-const { Diagram } = require('../entities/diagram');
-const { Blueprint } = require('../entities/blueprint');
-const { Workflow } = require('../entities/workflow');
-const { DiagramToWorkflow } = require('../entities/diagramToWorkflow');
+const { Diagram } = require("../entities/diagram");
+const { Blueprint } = require("../entities/blueprint");
+const { Workflow } = require("../entities/workflow");
+const { DiagramToWorkflow } = require("../entities/diagramToWorkflow");
 
 class KnexPersist {
   constructor(db, class_, table) {
@@ -11,141 +11,179 @@ class KnexPersist {
   }
 
   async delete(obj_id) {
-    return await this._db(this._table).where('id', obj_id).del();
+    return await this._db(this._table).where("id", obj_id).del();
   }
 
   async get(obj_id) {
-    return await this._db.select('*').from(this._table).where('id', obj_id).first();
+    return await this._db.select("*").from(this._table).where("id", obj_id).first();
   }
-
 }
 
 class DiagramKnexPersist extends KnexPersist {
   constructor(db) {
-    super(db, Diagram, 'diagrams');
+    super(db, Diagram, "diagrams");
   }
 
   async getAll() {
     const diagram_to_workflow = new DiagramToWorkflowKnexPersist(this._db);
     return await this._db(this._table)
-      .select('id', 'name', 'diagram_xml', 'blueprint_id','user_id', 'created_at', 
-      'updated_at', 'aligned', 'workflow_id')
+      .select(
+        "id",
+        "name",
+        "diagram_xml",
+        "blueprint_id",
+        "user_id",
+        "created_at",
+        "updated_at",
+        "aligned",
+        "workflow_id"
+      )
       .leftJoin(diagram_to_workflow._table, `${diagram_to_workflow._table}.diagram_id`, `${this._table}.id`)
-      .orderBy('updated_at', 'desc');
+      .orderBy("updated_at", "desc");
   }
 
   async save(diagram) {
     await this._db(this._table).insert(diagram);
-    return 'create';
+    return "create";
   }
 
   async update(diagram_id, diagram) {
-    return await this._db(this._table).where('id', diagram_id)
-      .update({...diagram, updated_at: 'now' })
-      .returning('*');
+    return await this._db(this._table)
+      .where("id", diagram_id)
+      .update({ ...diagram, updated_at: "now" })
+      .returning("*");
+  }
+
+  async delete(id) {
+    const diagram_to_workflow = new DiagramToWorkflowKnexPersist(this._db);
+    await this._db(diagram_to_workflow._table).where("diagram_id", id).del();
+    await this._db(this._table).where("id", id).del();
   }
 
   async getByUserId(user_id) {
     const diagram_to_workflow = new DiagramToWorkflowKnexPersist(this._db);
     return await this._db(this._table)
-      .select('id', 'name', 'diagram_xml', 'blueprint_id','user_id', 'created_at', 
-        'updated_at', 'aligned', 'workflow_id')
+      .select(
+        "id",
+        "name",
+        "diagram_xml",
+        "blueprint_id",
+        "user_id",
+        "created_at",
+        "updated_at",
+        "aligned",
+        "workflow_id"
+      )
       .leftJoin(diagram_to_workflow._table, `${diagram_to_workflow._table}.diagram_id`, `${this._table}.id`)
-      .where('user_id', user_id)
-      .orderBy('updated_at', 'desc');
+      .whereNull("user_id")
+      .orWhere("user_id", user_id)
+      .orderBy("updated_at", "desc");
   }
-  
-  async getByWorkflowId(workflow_id) {
+
+  async getByWorkflowId(workflow_id, user_id = null) {
     const diagram_to_workflow = new DiagramToWorkflowKnexPersist(this._db);
     return await this._db(this._table)
-      .select('id', 'name', 'diagram_xml', 'blueprint_id','user_id', 'created_at', 
-        'updated_at', 'aligned', 'workflow_id')
+      .select(
+        "id",
+        "name",
+        "diagram_xml",
+        "blueprint_id",
+        "user_id",
+        "created_at",
+        "updated_at",
+        "aligned",
+        "workflow_id"
+      )
       .join(diagram_to_workflow._table, `${diagram_to_workflow._table}.diagram_id`, `${this._table}.id`)
-      .where('workflow_id', workflow_id)
-      .orderBy('updated_at', 'desc');
+      .where("workflow_id", workflow_id)
+      .whereNull("user_id")
+      .orWhere({ user_id: user_id, workflow_id: workflow_id })
+      .orderBy("updated_at", "desc");
   }
-  
-  async getLatestByWorkflowId(workflow_id) {
-    const diagram_to_workflow = new DiagramToWorkflowKnexPersist(this._db);
-    return await this._db(this._table)
-      .select('id', 'name', 'diagram_xml', 'blueprint_id','user_id', 'created_at', 
-        'updated_at', 'aligned', 'workflow_id')
-      .join(diagram_to_workflow._table, `${diagram_to_workflow._table}.diagram_id`, `${this._table}.id`)
-      .where('workflow_id', workflow_id)
-      .orderBy('updated_at', 'desc')
-      .first();
+
+  async getLatestByWorkflowId(workflow_id, user_id = null) {
+    const workflows = await this.getByWorkflowId(workflow_id, user_id)
+    return workflows[0]
   }
-  
+
   async getByUserAndWF(user_id, workflow_id) {
     const diagram_to_workflow = new DiagramToWorkflowKnexPersist(this._db);
     return await this._db(this._table)
-      .select('id', 'name', 'diagram_xml', 'blueprint_id','user_id', 'created_at', 
-        'updated_at', 'aligned', 'workflow_id')
+      .select(
+        "id",
+        "name",
+        "diagram_xml",
+        "blueprint_id",
+        "user_id",
+        "created_at",
+        "updated_at",
+        "aligned",
+        "workflow_id"
+      )
       .join(diagram_to_workflow._table, `${diagram_to_workflow._table}.diagram_id`, `${this._table}.id`)
-      .where('workflow_id', workflow_id)
-      .andWhere('user_id', user_id)
-      .orderBy('updated_at', 'desc');
+      .where("workflow_id", workflow_id)
+      .andWhere("user_id", user_id)
+      .orderBy("updated_at", "desc");
   }
 }
 
 class BlueprintKnexPersist extends KnexPersist {
   constructor(db) {
-    super(db, Blueprint, 'blueprints');
+    super(db, Blueprint, "blueprints");
   }
 
   async save(blueprint) {
     await this._db(this._table).insert(blueprint);
-    return 'create';
+    return "create";
   }
 
   async update(id, blueprint_spec) {
-    return await this._db(this._table).where('id', id)
-      .update({ blueprint_spec })
-      .returning('*');
+    return await this._db(this._table).where("id", id).update({ blueprint_spec }).returning("*");
   }
 }
 
 class WorkflowKnexPersist extends KnexPersist {
   constructor(db) {
-    super(db, Workflow, 'workflows');
+    super(db, Workflow, "workflows");
   }
 
   async save(workflow) {
     await this._db(this._table).insert(workflow);
-    return 'create';
+    return "create";
   }
 
   async update(id, workflow) {
-    return await this._db(this._table).where('id', id)
+    return await this._db(this._table)
+      .where("id", id)
       .update({ ...workflow })
-      .returning('*');
+      .returning("*");
   }
 }
 
 class DiagramToWorkflowKnexPersist extends KnexPersist {
   constructor(db) {
-    super(db, DiagramToWorkflow, 'diagram_to_workflow');
+    super(db, DiagramToWorkflow, "diagram_to_workflow");
   }
 
   async save(workflow) {
     await this._db(this._table).insert(workflow);
-    return 'create';
+    return "create";
   }
 
   async getDiagramIdsByWorkflowId(workflow_id) {
-    return await this._db(this._table).select('*').where('workflow_id', workflow_id);
+    return await this._db(this._table).select("*").where("workflow_id", workflow_id);
   }
 
   async getWorkflowIdsByDiagramId(diagram_id) {
-    return await this._db(this._table).select('*').where('diagram_id', diagram_id);
+    return await this._db(this._table).select("*").where("diagram_id", diagram_id);
   }
 
   async deleteByDiagramId(diagram_id) {
-    return await this._db(this._table).where('diagram_id', diagram_id).del();
+    return await this._db(this._table).where("diagram_id", diagram_id).del();
   }
 
   async deleteByWorkflowId(workflow_id) {
-    return await this._db(this._table).where('workflow_id', workflow_id).del();
+    return await this._db(this._table).where("workflow_id", workflow_id).del();
   }
 }
 
@@ -153,5 +191,5 @@ module.exports = {
   DiagramKnexPersist,
   BlueprintKnexPersist,
   WorkflowKnexPersist,
-  DiagramToWorkflowKnexPersist
-}
+  DiagramToWorkflowKnexPersist,
+};

--- a/src/tests/diagramCore.test.js
+++ b/src/tests/diagramCore.test.js
@@ -1,9 +1,12 @@
+const { v4: uuid } = require('uuid'); 
 const { Diagram } = require('../entities/diagram');
 const { DiagramCore } = require('../diagramCore');
 const { validate } = require('uuid');
 const { PersistorProvider } = require("../persist/provider");
 const diagramExample = require('fs').readFileSync('./examples/diagram.xml', 'utf8');
 const { db } = require('../utils/db');
+const { blueprint_spec } = require('../../examples/blueprint');
+const _ = require('lodash')
 
 const diagramPayload = {
   name: 'Test',
@@ -44,7 +47,8 @@ describe('DiagramCore tests (without workflow_id)', () => {
   
   test('get diagrams by user_id', async () => {
     const diagramCore = new DiagramCore(db);
-    const diagramCreated = await diagramCore.saveDiagram(diagramPayload);
+    const payload = _.cloneDeep(diagramPayload)
+    const diagramCreated = await diagramCore.saveDiagram(payload);
     const diagrams = await diagramCore.getDiagramsByUserId('1');
     expect(diagrams.length).toBeTruthy();
     expect(diagrams[0].user_id).toEqual(diagramCreated.user_id);
@@ -52,15 +56,17 @@ describe('DiagramCore tests (without workflow_id)', () => {
   });
   
   test('get diagram by id', async () => {
-    const diagramCore = new DiagramCore(db);
-    const diagramCreated = await diagramCore.saveDiagram(diagramPayload);
+    const diagramCore = new DiagramCore(db);    
+    const payload = _.cloneDeep(diagramPayload)
+    const diagramCreated = await diagramCore.saveDiagram(payload);
     const diagram = await diagramCore.getDiagramById(diagramCreated.id);
     expect(diagram).toBeDefined();
   });
   
   test('update diagram', async () => {
     const diagramCore = new DiagramCore(db);
-    const diagramCreated = await diagramCore.saveDiagram(diagramPayload);
+    const payload = _.cloneDeep(diagramPayload)
+    const diagramCreated = await diagramCore.saveDiagram(payload);
     const diagramUpdated = await diagramCore.updateDiagram(diagramCreated.id, {
       name: 'Test Update',
       blueprint_id: '42a9a60e-e2e5-4d21-8e2f-67318b100e38',
@@ -73,7 +79,8 @@ describe('DiagramCore tests (without workflow_id)', () => {
   
   test('delete diagram', async () => {
     const diagramCore = new DiagramCore(db);
-    const diagramCreated = await diagramCore.saveDiagram(diagramPayload);
+    const payload = _.cloneDeep(diagramPayload)
+    const diagramCreated = await diagramCore.saveDiagram(payload);
     await diagramCore.deleteDiagram(diagramCreated.id);
     const diagram = await diagramCore.getDiagramById(diagramCreated.id);
     expect(diagram).not.toBeTruthy();
@@ -81,18 +88,48 @@ describe('DiagramCore tests (without workflow_id)', () => {
 });
 
 describe('DiagramCore tests (with workflow_id)', () => {
+  test('create diagram', async () => {
+    const diagramCore = new DiagramCore(db);
+    const payload = _.cloneDeep(diagramPayload)
+    payload.workflow_data = {
+      id: uuid(),
+      server: "vader.bunnyshell.com",
+      blueprint_spec
+    }
+    const diagram = await diagramCore.saveDiagram(payload);
+    expect(validate(diagram.id)).toBeTruthy();
+    expect(diagram.name).toEqual('Test');
+    expect(diagram.workflow_id).toBeDefined();
+    expect(diagram.server).toBeDefined();
+  });
 
   test('get diagrams by workflow_id', async () => {
     const diagramCore = new DiagramCore(db);
-    const diagrams = await diagramCore.getDiagramsByWorkflowId('ae7e95f6-787a-4c0b-8e1a-4cc122e7d68f');
-    expect(diagrams.length).toBeTruthy();
-    expect(diagrams[0].workflow_id).toEqual('ae7e95f6-787a-4c0b-8e1a-4cc122e7d68f');
+    const payload = _.cloneDeep(diagramPayload)
+    const workflowId = uuid()
+    payload.workflow_data = {
+      id: workflowId,
+      server: "vader.bunnyshell.com",
+      blueprint_spec
+    }
+    const diagram = await diagramCore.saveDiagram(payload);
+    const diagrams = await diagramCore.getDiagramsByWorkflowId(workflowId, '1');
+    expect(diagrams.length).toEqual(1);
+    expect(diagrams[0].id).toEqual(diagram.id);
   });
   
   test('get latest diagram by workflow_id', async () => {
     const diagramCore = new DiagramCore(db);
-    const diagram = await diagramCore.getLatestDiagramByWorkflowId('ae7e95f6-787a-4c0b-8e1a-4cc122e7d68f');
-    expect(diagram.workflow_id).toEqual('ae7e95f6-787a-4c0b-8e1a-4cc122e7d68f');
+    const payload = _.cloneDeep(diagramPayload)
+    const workflowId = uuid()
+    payload.workflow_data = {
+      id: workflowId,
+      server: "vader.bunnyshell.com",
+      blueprint_spec
+    }
+    const diagram = await diagramCore.saveDiagram(payload);
+    const result = await diagramCore.getLatestDiagramByWorkflowId(workflowId, '1');
+    expect(result.id).toEqual(diagram.id);
   });
   
   test('get diagrams by user_id and workflow_id', async () => {
@@ -101,5 +138,55 @@ describe('DiagramCore tests (with workflow_id)', () => {
     expect(diagrams.length).toBeTruthy();
     expect(diagrams[0].user_id).toEqual('1');
     expect(diagrams[0].workflow_id).toEqual('ae7e95f6-787a-4c0b-8e1a-4cc122e7d68f');
+  });
+});
+
+describe('DiagramCore tests (public diagrams)', () => {
+  test('create diagram', async () => {
+    const diagramCore = new DiagramCore(db);
+    const payload = _.cloneDeep(diagramPayload)
+    payload.workflow_data = {
+      id: uuid(),
+      server: "vader.bunnyshell.com",
+      blueprint_spec
+    }
+    payload.isPublic = true;
+    const diagram = await diagramCore.saveDiagram(payload);
+    expect(validate(diagram.id)).toBeTruthy();
+    expect(diagram.name).toEqual('Test');
+    expect(diagram.workflow_id).toBeDefined();
+    expect(diagram.server).toBeDefined();
+    expect(diagram.user_id).toBeNull();
+  });
+
+  test('get diagrams by workflow_id', async () => {
+    const diagramCore = new DiagramCore(db);
+    const payload = _.cloneDeep(diagramPayload)
+    const workflowId = uuid()
+    payload.workflow_data = {
+      id: workflowId,
+      server: "vader.bunnyshell.com",
+      blueprint_spec
+    }
+    payload.isPublic = true;
+    const diagram = await diagramCore.saveDiagram(payload);
+    const diagrams = await diagramCore.getDiagramsByWorkflowId(workflowId);
+    expect(diagrams.length).toEqual(1);
+    expect(diagrams[0].id).toEqual(diagram.id);
+  });
+  
+  test('get latest diagram by workflow_id', async () => {
+    const diagramCore = new DiagramCore(db);
+    const payload = _.cloneDeep(diagramPayload)
+    const workflowId = uuid()
+    payload.workflow_data = {
+      id: workflowId,
+      server: "vader.bunnyshell.com",
+      blueprint_spec
+    }
+    payload.isPublic = true;
+    const diagram = await diagramCore.saveDiagram(payload);
+    const result = await diagramCore.getLatestDiagramByWorkflowId(workflowId);
+    expect(result.id).toEqual(diagram.id);
   });
 });


### PR DESCRIPTION
Include a parameter during diagram save to allow saving a diagram without user_id.
diagrams without user_id area considered public diagrams. They can be read by any user.

When saving a wirnkflow, allow sending a workflow_data object that creates a workflow relationship and a blueprint relationship.