### PR TITLE
Blueprints and Workflow Save

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ const diagramCore = new DiagramCore(db);
 // note that 'db' has to be a database configuration
 ```
 
+The service does have a blueprint storage, but it only stores the data relevant to the diagram, a.k.a. nodes and lanes (prepare, environment and parameters are discarded).  
+
 ## Environment variables
 
 Add a .env file with the following variables:

--- a/src/entities/blueprint.js
+++ b/src/entities/blueprint.js
@@ -1,6 +1,29 @@
-const { v4: uuid } = require('uuid');
-const { PersistedEntity } = require('./base');
-const _ = require('lodash');
+const { v4: uuid } = require("uuid");
+const { PersistedEntity } = require("./base");
+const _ = require("lodash");
+
+const sortById = (array) => {
+  return array.sort((a, b) => {
+    let x = a.id.toLowerCase();
+    let y = b.id.toLowerCase();
+    if (x > y) {
+      return 1;
+    }
+    if (x < y) {
+      return -1;
+    }
+    return 0;
+  })
+};
+
+const organize = (spec) => {
+  const lanes = sortById(spec.lanes);
+  const nodes = sortById(spec.nodes);
+  return {
+    lanes,
+    nodes,
+  };
+}
 
 class Blueprint extends PersistedEntity {
   static getEntityClass() {
@@ -11,7 +34,7 @@ class Blueprint extends PersistedEntity {
     if (!serialized) {
       return;
     }
-    
+
     if (_.isArray(serialized)) {
       return serialized.map((data) => this._deserialized(data));
     } else {
@@ -22,26 +45,28 @@ class Blueprint extends PersistedEntity {
   static _deserialized(data) {
     return {
       id: data.id,
-      blueprint_spec: data.blueprint_spec
-    }
+      blueprint_spec: data.blueprint_spec,
+    };
   }
 
   static serialize(blueprint) {
     return {
       id: blueprint.id,
-      blueprint_spec: blueprint.blueprint_spec
-    }
+      blueprint_spec: organize(blueprint.blueprint_spec),
+    };
   }
 
   constructor(blueprint_spec) {
     super();
-
     this.id = uuid();
-    this.blueprint_spec = blueprint_spec;
+    this.blueprint_spec = organize(blueprint_spec);
   }
 
+  async save(...args) {
+    return await this.getPersist().save(this.serialize(), ...args);
+  }
 }
 
 module.exports = {
-  Blueprint
-}
+  Blueprint,
+};

--- a/src/persist/knex.js
+++ b/src/persist/knex.js
@@ -133,8 +133,14 @@ class BlueprintKnexPersist extends KnexPersist {
   }
 
   async save(blueprint) {
-    await this._db(this._table).insert(blueprint);
-    return "create";
+    let result;
+    result = await this._db(this._table).where('blueprint_spec', blueprint.blueprint_spec);
+    if(result.length === 0) {
+      const insertResult = await this._db(this._table).insert(blueprint).returning('*');
+      return insertResult[0]
+    } else {
+      return result[0];
+    }
   }
 
   async update(id, blueprint_spec) {
@@ -148,7 +154,11 @@ class WorkflowKnexPersist extends KnexPersist {
   }
 
   async save(workflow) {
-    await this._db(this._table).insert(workflow);
+    //TODO: workflow.id is not unique. The same id can appear on different servers. Need to adjust the migrations to set the unique key to id + server.
+    const existing = await this.get(workflow.id)
+    if(!existing) {
+      await this._db(this._table).insert(workflow);  
+    }
     return "create";
   }
 

--- a/src/tests/blueprintCore.test.js
+++ b/src/tests/blueprintCore.test.js
@@ -38,7 +38,6 @@ describe('BlueprintCore tests ', () => {
     const blueprintCore = new BlueprintCore(db);
     const blueprintCreated = await blueprintCore.saveBlueprint(blueprint_spec);
     expect(validate(blueprintCreated.id)).toBeTruthy();
-    expect(blueprintCreated.blueprint_spec).toEqual(blueprint_spec);
   });
   
   test('get blueprint by id', async () => {
@@ -46,7 +45,7 @@ describe('BlueprintCore tests ', () => {
     const blueprintCreated = await blueprintCore.saveBlueprint(blueprint_spec);
     const blueprint = await blueprintCore.getBlueprintById(blueprintCreated.id);
     expect(blueprint.id).toEqual(blueprintCreated.id);
-    expect(blueprint.blueprint_spec).toEqual(blueprint_spec);
+    expect(blueprint.blueprint_spec).toBeDefined();
   });
 
   test('update blueprint', async () => {
@@ -54,7 +53,6 @@ describe('BlueprintCore tests ', () => {
     const blueprintUpdated = await blueprintCore
       .updateBlueprint('42a9a60e-e2e5-4d21-8e2f-67318b100e38', blueprint_spec);
     expect(validate(blueprintUpdated.id)).toBeTruthy();
-    expect(blueprintUpdated.blueprint_spec).toEqual(blueprint_spec);
   });
 
   test('delete blueprint', async () => {

--- a/src/tests/unit/blueprint.test.js
+++ b/src/tests/unit/blueprint.test.js
@@ -16,13 +16,23 @@ afterAll(async () => {
 });
 
 describe('Blueprint tests', () => {
-
   test('save blueprint', async () => {
     const blueprintInstance = new Blueprint(blueprint_spec);
     const saved_blueprint = await blueprintInstance.save();
-    expect(validate(saved_blueprint.id)).toBeTruthy();
-    expect(saved_blueprint.id).toEqual(blueprintInstance.id);
-    expect(saved_blueprint.blueprint_spec).toEqual(blueprint_spec);
+    expect(saved_blueprint.id).toBeDefined();
+    expect(saved_blueprint.blueprint_spec.lanes).toBeDefined();
+    expect(saved_blueprint.blueprint_spec.nodes).toBeDefined();
+    expect(saved_blueprint.blueprint_spec.environment).toBeUndefined();
+  });
+
+  test('save the same blueprint twice', async () => {
+    const firstBlueprintInstance = new Blueprint(blueprint_spec);
+    const firstSavedBlueprint = await firstBlueprintInstance.save();
+    expect(validate(firstSavedBlueprint.id)).toBeTruthy();
+    
+    const secondBlueprintInstance = new Blueprint(blueprint_spec);
+    const secondSavedBlueprint = await secondBlueprintInstance.save();
+    expect(secondSavedBlueprint.id).toEqual(firstSavedBlueprint.id);
   });
 
   test('get blueprint by id', async () => {
@@ -31,6 +41,8 @@ describe('Blueprint tests', () => {
     const fetched_blueprint = await Blueprint.fetch(saved_blueprint.id);
     expect(validate(fetched_blueprint.id)).toBeTruthy();
     expect(fetched_blueprint.id).toEqual(saved_blueprint.id);
-    expect(fetched_blueprint.blueprint_spec).toEqual(blueprint_spec);
+    expect(saved_blueprint.blueprint_spec.lanes).toBeDefined();
+    expect(saved_blueprint.blueprint_spec.nodes).toBeDefined();
+    expect(saved_blueprint.blueprint_spec.environment).toBeUndefined();
   });
 });

--- a/src/tests/unit/workflow.test.js
+++ b/src/tests/unit/workflow.test.js
@@ -17,7 +17,7 @@ afterAll(async () => {
 
 describe('Workflow tests', () => {
 
-  test('save workflow', async () => {
+  test('save workflow once', async () => {
     const workflowInstance = new Workflow('325c80a7-35c4-4af9-83b0-58e40af88b05',
       'http://localhost:3000', '42a9a60e-e2e5-4d21-8e2f-67318b100e38');
     const saved_workflow = await workflowInstance.save();
@@ -26,6 +26,19 @@ describe('Workflow tests', () => {
     expect(saved_workflow.server).toEqual('http://localhost:3000');
     expect(saved_workflow.blueprint_id).toEqual('42a9a60e-e2e5-4d21-8e2f-67318b100e38');
   });
+
+  test('save workflow twice', async () => {
+    const firstWorkflowInstance = new Workflow('325c80a7-35c4-4af9-83b0-58e40af88b05',
+      'http://localhost:3000', '42a9a60e-e2e5-4d21-8e2f-67318b100e38');
+    const firstSavedWorkflow = await firstWorkflowInstance.save();
+    expect(validate(firstSavedWorkflow.id)).toBeTruthy();
+    
+    const secondWorkflowInstance = new Workflow('325c80a7-35c4-4af9-83b0-58e40af88b05',
+      'http://localhost:3000', '42a9a60e-e2e5-4d21-8e2f-67318b100e38');
+    const secondSavedWorkflow = await secondWorkflowInstance.save();
+    expect(validate(secondSavedWorkflow.id)).toBeTruthy();
+    expect(secondSavedWorkflow.id).toEqual(firstSavedWorkflow.id)
+  })
 
   test('fetch workflow by id', async () => {
     const fetched_workflow = await Workflow.fetch('325c80a7-35c4-4af9-83b0-58e40af88b05');


### PR DESCRIPTION
Changes how the blueprints and workflows area saved.

Workflows
- before saving, checks if the workflow already exists.
- the workflow_id is being considered as unique key. In fact, the key should be workflow_id + server. A refactor needs to be done in the near future.

Blueprints
- before saving, checks whether exists the same spec in the database.
- in order to have a fair object comparison (considering the diagram context), the properties that does not affect the diagram are discarded and the lanes and nodes are sorted by id.