### PR TITLE
chore(release): 1.6.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flowbuild/diagrams-core",
-  "version": "1.5.0",
+  "version": "1.6.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flowbuild/diagrams-core",
-      "version": "1.5.0",
+      "version": "1.6.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowbuild/diagrams-core",
-  "version": "1.5.0",
+  "version": "1.6.0-rc.1",
   "description": "BPMN diagrams manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.6.0-rc.1](https://github.com/flow-build/diagrams-core/releases/tag/v1.6.0-rc.1)