### PR TITLE
chore(release): 1.6.0-rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flowbuild/diagrams-core",
-  "version": "1.6.0-rc.1",
+  "version": "1.6.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flowbuild/diagrams-core",
-      "version": "1.6.0-rc.1",
+      "version": "1.6.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "dotenv": "16.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowbuild/diagrams-core",
-  "version": "1.6.0-rc.1",
+  "version": "1.6.0-rc.2",
   "description": "BPMN diagrams manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.6.0-rc.2](https://github.com/flow-build/diagrams-core/releases/tag/v1.6.0-rc.2)